### PR TITLE
Update rate action response to meet the functional requirements

### DIFF
--- a/src/Application/Actions/Charge/RateChargeDetailRecordAction.php
+++ b/src/Application/Actions/Charge/RateChargeDetailRecordAction.php
@@ -46,6 +46,11 @@ class RateChargeDetailRecordAction extends Action
         $rateCalculator = new RateCalculator($rate, $cdr);
         $this->logger->info('test', [$rateCalculator]);
 
-        return $this->respondWithData($rateCalculator);
+        $json = json_encode($rateCalculator, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+        $this->response->getBody()->write($json);
+
+        return $this->response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(200);
     }
 }

--- a/tests/Application/Actions/Charge/RateChargeDetailRecordActionTest.php
+++ b/tests/Application/Actions/Charge/RateChargeDetailRecordActionTest.php
@@ -34,10 +34,10 @@ class RateChargeDetailRecordActionTest extends TestCase
         $response = $app->handle($request);
 
         $payload = (string)$response->getBody();
-        $expectedPayload = new ActionPayload(200, [
+        $expectedPayload = [
             'overall' => 7.04,
             'components' => ['energy' => 3.277, 'time' => 2.767, 'transaction' => 1],
-        ]);
+        ];
         $serializedPayload = json_encode($expectedPayload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
 
         $this->assertEquals($serializedPayload, $payload);


### PR DESCRIPTION
**To meet functional requirements** 😅

The way that the response are formatted right now ( I mean on master branch commit [367b657](https://github.com/mehrna/csms/commit/367b657300c4b3b947e5cc81af65f706a512fba0) )is much more convenient and well designed than the way on the assessment need, by the way, to meet the Functional requirements, I did it the other way in this pull request.